### PR TITLE
Masking no data region of TIFF images.

### DIFF
--- a/resippy/photogrammetry/ortho_tools.py
+++ b/resippy/photogrammetry/ortho_tools.py
@@ -90,7 +90,7 @@ def get_pixel_lon_lats(overhead_image,  # type: AbstractEarthOverheadImage
 def mask_image(image, nodata_val=0):
     """
     Mask tiff images to make the nodata_val region transparent. One alpha channel is added to the image.
-    Value of 0 for alpha: full transparency
+    Value of 0 for alpha: full transparent
     Value of 255 for alpha: fully opaque
 
     :param image: a single or multi-band (orthorectified) image.

--- a/resippy/photogrammetry/ortho_tools.py
+++ b/resippy/photogrammetry/ortho_tools.py
@@ -93,8 +93,8 @@ def mask_image(image, nodata_val=0):
     Value of 0 for alpha: full transparent
     Value of 255 for alpha: fully opaque
 
-    # Note: Given that by default black pixels in channel 0 / band 1 are masked, masking gets broken for relatively darker
-    images.
+    # Note: Given that by default black pixels in channel 0 / band 1 are masked, masking gets broken
+    for relatively darker images.
 
     :param image: a single or multi-band (orthorectified) image.
     :return: input image with an added alpha layer which masks nodata_val region.

--- a/resippy/photogrammetry/ortho_tools.py
+++ b/resippy/photogrammetry/ortho_tools.py
@@ -93,10 +93,13 @@ def mask_image(image, nodata_val=0):
     Value of 0 for alpha: full transparent
     Value of 255 for alpha: fully opaque
 
+    # Note: Given that by default black pixels in channel 0 / band 1 are masked, masking gets broken for relatively darker
+    images.
+
     :param image: a single or multi-band (orthorectified) image.
     :return: input image with an added alpha layer which masks nodata_val region.
     """
-    layer = image[:, :, 0]
+    layer = image[:, :, 0]  # Take band 0 as the reference layer to mask the image.
     alpha = layer.copy()
     alpha[layer == nodata_val] = 0
     alpha[layer != nodata_val] = 255


### PR DESCRIPTION
I added an optional feature of masking TIFF images when doing orthorectification (create_ortho_gtiff_image_world_to_sensor). I added optional flags so it does not break the existing resippy code in any way.

I have documented my feature as well. Please let me know if any other changes are necessary before the code can be merged.